### PR TITLE
20250730-이준영

### DIFF
--- a/kbs/backend/src/main/java/com/kimbap/kbs/materials/mapper/MateMapper.java
+++ b/kbs/backend/src/main/java/com/kimbap/kbs/materials/mapper/MateMapper.java
@@ -1,6 +1,7 @@
 package com.kimbap.kbs.materials.mapper;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.ibatis.annotations.Param;
 
@@ -8,22 +9,29 @@ import com.kimbap.kbs.materials.service.MaterialsVO;
 import com.kimbap.kbs.materials.service.SearchCriteria;
 
 public interface MateMapper {
+
     // ========== 기존 메서드들 ==========
     void insertPurcOrd(MaterialsVO purcOrd);
+
     void updatePurcOrd(MaterialsVO purcOrd);
+
     List<MaterialsVO> getPurcOrdList();
+
     List<MaterialsVO> getPurcOrdList(SearchCriteria criteria);
 
     void insertMateInbo(MaterialsVO mateInbo);
+
     List<MaterialsVO> getMateInboList();
+
     void updateMateInbo(MaterialsVO mateInbo);
+
     MaterialsVO getMateInboById(String mateInboCd);
 
     List<MaterialsVO> getMateRelList();
-    void insertMateRel(MaterialsVO mateRel);
-    
-    // ========== 새로 추가된 발주서 관련 메서드 ==========
 
+    void insertMateRel(MaterialsVO mateRel);
+
+    // ========== 새로 추가된 발주서 관련 메서드 ==========
     /**
      * 발주서 목록 조회 (모달용)
      */
@@ -76,7 +84,44 @@ public interface MateMapper {
 
     MaterialsVO getMateSupplierByKey(SearchCriteria criteria);
 
-    String getMateCpCd(@Param("mcode") String mcode, 
-                   @Param("mateVerCd") String mateVerCd, 
-                   @Param("cpCd") String cpCd);
+    String getMateCpCd(@Param("mcode") String mcode,
+            @Param("mateVerCd") String mateVerCd,
+            @Param("cpCd") String cpCd);
+
+    List<MaterialsVO> getPurcOrderDetailListForApproval();
+
+    /**
+     * 🔄 발주 상세 상태 업데이트 (승인/반려용)
+     */
+    void updatePurcOrderDetailStatus(MaterialsVO statusData);
+
+    /**
+     * 🔄 발주 헤더 상태 업데이트
+     */
+    void updatePurcOrderHeaderStatus(MaterialsVO headerData);
+
+    /**
+     * 📋 승인 대기 발주 목록 조회 (상세 정보 포함)
+     */
+    List<MaterialsVO> getPendingApprovalOrdersDetailed(SearchCriteria criteria);
+
+    /**
+     * 📊 발주 상태별 통계 조회
+     */
+    List<Map<String, Object>> getPurchaseOrderStatusStatistics(SearchCriteria criteria);
+
+    /**
+     * 📊 월별 발주 통계 조회
+     */
+    List<Map<String, Object>> getMonthlyPurchaseStatistics(SearchCriteria criteria);
+
+    /**
+     * 📊 공급업체별 발주 통계 조회
+     */
+    List<Map<String, Object>> getSupplierPurchaseStatistics(SearchCriteria criteria);
+
+    /**
+     * 🔍 발주 상세 정보 조회 (승인 이력 포함)
+     */
+    MaterialsVO getPurchaseOrderDetailWithHistory(String purcDCd);
 }

--- a/kbs/backend/src/main/java/com/kimbap/kbs/materials/service/MateService.java
+++ b/kbs/backend/src/main/java/com/kimbap/kbs/materials/service/MateService.java
@@ -2,31 +2,77 @@ package com.kimbap.kbs.materials.service;
 
 import java.util.List;
 import java.util.Map;
+
 public interface MateService {
-    
+
     // 자재입고 관련 메서드
     void insertMateInbo(MaterialsVO mateInbo);
+
     List<MaterialsVO> getMateInboList();
+
     void updateMateInbo(MaterialsVO mateInbo);
+
     MaterialsVO getMateInboById(String mateInboCd);
 
     // 발주 관련 메서드
     List<MaterialsVO> getPurcOrdList();
+
     List<MaterialsVO> getPurchaseOrders(SearchCriteria criteria);
+
     List<MaterialsVO> getPurcOrderList();
+
     Map<String, Object> getPurcOrderWithDetails(String purcCd);
+
     List<MaterialsVO> getMaterialWithSuppliers(SearchCriteria criteria);
+
     String savePurchaseOrder(Map<String, Object> orderData);
+
     String generatePurchaseCode();
+
     List<MaterialsVO> getSuppliersByMaterial(SearchCriteria criteria);
+
     List<MaterialsVO> getMaterialsBySupplier(SearchCriteria criteria);
 
     // 자재출고 관련 메서드
     List<MaterialsVO> getMateRelList();
+
     void insertMateRel(MaterialsVO mateRel);
-    
+
     // 공장목록 조회 메서드
     List<MaterialsVO> getActiveFactoryList();
 
     // 발주서 승인 관련 메서드
+    List<MaterialsVO> getPurcOrderDetailListForApproval();
+
+    /**
+     * 🔄 발주 상태 업데이트 (승인/반려용)
+     *
+     * @param statusData 상태 변경 데이터 (purcDCd, purcDStatus 포함)
+     */
+    void updatePurchaseOrderStatus(MaterialsVO statusData);
+
+    /**
+     * 📋 승인 대기 발주 목록 조회
+     *
+     * @param criteria 검색 조건
+     * @return 승인 대기 발주 목록
+     */
+    List<MaterialsVO> getPendingApprovalOrders(SearchCriteria criteria);
+
+    /**
+     * 📊 발주 통계 조회
+     *
+     * @param criteria 기간 조건
+     * @return 발주 통계 데이터
+     */
+    Map<String, Object> getPurchaseOrderStatistics(SearchCriteria criteria);
+
+    /**
+     * 🔔 발주 상태 변경 알림 처리
+     *
+     * @param purcDCd 발주상세코드
+     * @param newStatus 새로운 상태
+     * @param approver 승인자
+     */
+    void sendStatusChangeNotification(String purcDCd, String newStatus, String approver);
 }

--- a/kbs/backend/src/main/java/com/kimbap/kbs/materials/service/MaterialsVO.java
+++ b/kbs/backend/src/main/java/com/kimbap/kbs/materials/service/MaterialsVO.java
@@ -30,6 +30,7 @@ public class MaterialsVO {
     private String regiName;        // 담당자명
     private String purcStatus;      // 발주상태 ✅ 추가
     private String mateCpCd;       // 자재거래처코드
+    private String empName;
 
     // ========== p1 권한 추가 필드 ==========
     private String purcDCd;         // 발주상세코드

--- a/kbs/backend/src/main/resources/mapper/materials/MateMapper.xml
+++ b/kbs/backend/src/main/resources/mapper/materials/MateMapper.xml
@@ -205,19 +205,6 @@
     <select id="getPurcOrdList" parameterType="map" resultType="com.kimbap.kbs.materials.service.MaterialsVO">
     SELECT 
     <choose>
-        <when test="memtype == 'p1'">
-            po.purc_cd,
-            pod.purc_d_cd,
-            mat.mate_name,
-            mat.mate_type,
-            pod.purc_qty,
-            pod.unit,
-            pod.ex_deli_dt,
-            mati.deli_dt,
-            pod.purc_d_status,
-            po.ord_dt,
-            pod.note
-        </when>
         <when test="memtype == 'p3'">
             po.purc_cd,
             pod.purc_d_cd,
@@ -225,10 +212,27 @@
             mat.mate_name,
             pod.purc_qty,
             pod.unit,
+            pod.unit_price,
             pod.ex_deli_dt,
             mati.deli_dt,
             pod.purc_d_status,
             (pod.purc_qty * pod.unit_price) AS total_amount,
+            pod.note
+        </when>
+        <when test="memtype == 'p3'">
+            <!-- 공급업체용도 동일하게 보강 -->
+            po.purc_cd,
+            pod.purc_d_cd,
+            pod.mcode,
+            mat.mate_name,
+            pod.purc_qty,
+            pod.unit,
+            pod.unit_price,                                    -- 🔥 추가!
+            pod.ex_deli_dt,
+            pod.purc_d_status,
+            (pod.purc_qty * pod.unit_price) AS total_amount,   -- 🔥 추가!
+            po.regi,                                           -- 🔥 추가!
+            e.emp_name AS regi_name,                          -- 🔥 추가!
             pod.note
         </when>
         <otherwise>
@@ -242,6 +246,7 @@
         LEFT JOIN purc_ord_d pod ON po.purc_cd = pod.purc_cd
         LEFT JOIN material mat ON pod.mcode = mat.mcode
         LEFT JOIN mate_inbo mati ON pod.purc_d_cd = mati.purc_d_cd
+        LEFT JOIN employee e ON po.regi = e.emp_cd 
         <where>
             <if test="purcCd != null and purcCd != ''">
                 AND UPPER(po.purc_cd) LIKE UPPER('%' || #{purcCd} || '%')
@@ -519,6 +524,210 @@
             WHERE purc_d_cd LIKE 'PURC-D-%'
             ORDER BY purc_d_cd DESC
         ) WHERE ROWNUM = 1
+    </select>
+
+    <select id="getPurcOrderDetailListForApproval" resultType="com.kimbap.kbs.materials.service.MaterialsVO">
+        SELECT 
+            po.purc_cd,
+            po.ord_dt,
+            po.regi,
+            po.purc_status,
+            po.ord_total_amount,
+            pod.purc_d_cd,
+            pod.purc_qty,
+            pod.unit_price,
+            pod.ex_deli_dt,
+            pod.note,
+            pod.purc_d_status,
+            m.mate_name,
+            c.cp_name
+        FROM purc_ord po
+        INNER JOIN purc_ord_d pod ON po.purc_cd = pod.purc_cd
+        INNER JOIN material m ON pod.mcode = m.mcode AND pod.mate_ver_cd = m.mate_ver_cd
+        INNER JOIN mate_supplier ms ON pod.mate_cp_cd = ms.mate_cp_cd
+        INNER JOIN company c ON ms.cp_cd = c.cp_cd
+        WHERE po.purc_status IN ('c1', 'c2')  -- 승인 대기 중인 것들만
+        ORDER BY po.ord_dt DESC, pod.purc_d_cd
+    </select>
+
+    <!-- 🔄 발주 상세 상태 업데이트 (승인/반려용) -->
+    <update id="updatePurcOrderDetailStatus" parameterType="com.kimbap.kbs.materials.service.MaterialsVO">
+        UPDATE purc_ord_d 
+        SET purc_d_status = #{purcDStatus}
+        <if test="note != null and note != ''">
+            , note = #{note}
+        </if>
+        WHERE purc_d_cd = #{purcDCd}
+    </update>
+
+    <!-- 🔄 발주 헤더 상태 업데이트 -->
+    <update id="updatePurcOrderHeaderStatus" parameterType="com.kimbap.kbs.materials.service.MaterialsVO">
+        UPDATE purc_ord 
+        SET purc_status = #{purcStatus}
+        WHERE purc_cd = #{purcCd}
+    </update>
+
+    <!-- 📋 승인 대기 발주 목록 조회 (상세 정보 포함) -->
+    <select id="getPendingApprovalOrdersDetailed" resultType="com.kimbap.kbs.materials.service.MaterialsVO">
+        SELECT 
+            po.purc_cd,
+            po.ord_dt,
+            po.regi,
+            po.purc_status,
+            po.ord_total_amount,
+            
+            -- 발주상세 정보
+            pod.purc_d_cd,
+            pod.mate_cp_cd,
+            pod.mcode,
+            pod.mate_ver_cd,
+            pod.purc_qty,
+            pod.unit,
+            pod.unit_price,
+            pod.ex_deli_dt,
+            pod.note,
+            pod.purc_d_status,
+            
+            -- 자재 정보
+            m.mate_name,
+            m.mate_type,
+            m.std,
+            m.sto_con,
+            
+            -- 거래처 정보
+            c.cp_cd,
+            c.cp_name,
+            c.cp_type,
+            c.repname,
+            c.tel as cp_tel,
+            c.address as cp_address,
+            
+            e.emp_name as regi_name,
+            e.emp_name as emp_name
+            
+        FROM purc_ord po
+        INNER JOIN purc_ord_d pod ON po.purc_cd = pod.purc_cd
+        INNER JOIN material m ON pod.mcode = m.mcode AND pod.mate_ver_cd = m.mate_ver_cd
+        INNER JOIN mate_supplier ms ON pod.mate_cp_cd = ms.mate_cp_cd
+        INNER JOIN company c ON ms.cp_cd = c.cp_cd
+        LEFT JOIN employee e ON po.regi = e.emp_cd
+        WHERE pod.purc_d_status = 'c1'  -- 승인 대기 상태만
+        <if test="purcCd != null and purcCd != ''">
+            AND UPPER(po.purc_cd) LIKE UPPER('%' || #{purcCd} || '%')
+        </if>
+        <if test="mateName != null and mateName != ''">
+            AND UPPER(m.mate_name) LIKE UPPER('%' || #{mateName} || '%')
+        </if>
+        <if test="cpName != null and cpName != ''">
+            AND UPPER(c.cp_name) LIKE UPPER('%' || #{cpName} || '%')
+        </if>
+        <if test="startDate != null and startDate != ''">
+            AND po.ord_dt &gt;= TO_DATE(#{startDate}, 'YYYY-MM-DD')
+        </if>
+        <if test="endDate != null and endDate != ''">
+            AND po.ord_dt &lt;= TO_DATE(#{endDate}, 'YYYY-MM-DD')
+        </if>
+        ORDER BY po.ord_dt DESC, pod.purc_d_cd ASC
+    </select>
+
+    <!-- 📊 발주 상태별 통계 조회 -->
+    <select id="getPurchaseOrderStatusStatistics" resultType="java.util.Map">
+        SELECT 
+            purc_d_status as status,
+            COUNT(*) as count,
+            SUM(purc_qty * unit_price) as total_amount
+        FROM purc_ord_d pod
+        INNER JOIN purc_ord po ON pod.purc_cd = po.purc_cd
+        WHERE 1=1
+        <if test="startDate != null and startDate != ''">
+            AND po.ord_dt &gt;= TO_DATE(#{startDate}, 'YYYY-MM-DD')
+        </if>
+        <if test="endDate != null and endDate != ''">
+            AND po.ord_dt &lt;= TO_DATE(#{endDate}, 'YYYY-MM-DD')
+        </if>
+        GROUP BY purc_d_status
+        ORDER BY purc_d_status
+    </select>
+
+    <!-- 📊 월별 발주 통계 조회 -->
+        <select id="getMonthlyPurchaseStatistics" resultType="java.util.Map">
+        SELECT 
+            TO_CHAR(po.ord_dt, 'YYYY-MM') as order_month,
+            COUNT(*) as order_count,
+            SUM(pod.purc_qty * pod.unit_price) as total_amount,
+            COUNT(DISTINCT po.purc_cd) as unique_orders,
+            COUNT(DISTINCT ms.cp_cd) as unique_suppliers
+        FROM purc_ord po
+        INNER JOIN purc_ord_d pod ON po.purc_cd = pod.purc_cd
+        INNER JOIN mate_supplier ms ON pod.mate_cp_cd = ms.mate_cp_cd
+        WHERE 1=1
+        <if test="startDate != null and startDate != ''">
+            AND po.ord_dt &gt;= TO_DATE(#{startDate}, 'YYYY-MM-DD')
+        </if>
+        <if test="endDate != null and endDate != ''">
+            AND po.ord_dt &lt;= TO_DATE(#{endDate}, 'YYYY-MM-DD')
+        </if>
+        GROUP BY TO_CHAR(po.ord_dt, 'YYYY-MM')
+        ORDER BY order_month DESC
+    </select>
+
+    <!-- 📊 공급업체별 발주 통계 조회 -->
+    <select id="getSupplierPurchaseStatistics" resultType="java.util.Map">
+        SELECT 
+            c.cp_name as supplier_name,
+            c.cp_cd as supplier_code,
+            COUNT(*) as order_count,
+            SUM(pod.purc_qty * pod.unit_price) as total_amount,
+            AVG(pod.purc_qty * pod.unit_price) as avg_amount
+        FROM purc_ord po
+        INNER JOIN purc_ord_d pod ON po.purc_cd = pod.purc_cd
+        INNER JOIN mate_supplier ms ON pod.mate_cp_cd = ms.mate_cp_cd
+        INNER JOIN company c ON ms.cp_cd = c.cp_cd
+        WHERE 1=1
+        <if test="startDate != null and startDate != ''">
+            AND po.ord_dt &gt;= TO_DATE(#{startDate}, 'YYYY-MM-DD')
+        </if>
+        <if test="endDate != null and endDate != ''">
+            AND po.ord_dt &lt;= TO_DATE(#{endDate}, 'YYYY-MM-DD')
+        </if>
+        GROUP BY c.cp_name, c.cp_cd
+        ORDER BY total_amount DESC
+        FETCH FIRST 10 ROWS ONLY
+    </select>
+
+    <!-- 🔍 발주 상세 정보 조회 (승인 이력 포함) -->
+    <select id="getPurchaseOrderDetailWithHistory" parameterType="String" resultType="com.kimbap.kbs.materials.service.MaterialsVO">
+        SELECT 
+            pod.purc_d_cd,
+            pod.purc_cd,
+            pod.mcode,
+            pod.mate_ver_cd,
+            pod.purc_qty,
+            pod.unit,
+            pod.unit_price,
+            pod.ex_deli_dt,
+            pod.note,
+            pod.purc_d_status,
+            
+            -- 자재 정보
+            m.mate_name,
+            m.mate_type,
+            
+            -- 거래처 정보
+            c.cp_name,
+            c.repname,
+            
+            -- 발주 기본 정보
+            po.ord_dt,
+            po.regi,
+            po.purc_status
+            
+        FROM purc_ord_d pod
+        INNER JOIN purc_ord po ON pod.purc_cd = po.purc_cd
+        INNER JOIN material m ON pod.mcode = m.mcode AND pod.mate_ver_cd = m.mate_ver_cd
+        INNER JOIN mate_supplier ms ON pod.mate_cp_cd = ms.mate_cp_cd
+        INNER JOIN company c ON ms.cp_cd = c.cp_cd
+        WHERE pod.purc_d_cd = #{purcDCd}
     </select>
     
     <!-- 자재출고 목록 조회 -->

--- a/kbs/frontend/src/api/materials.js
+++ b/kbs/frontend/src/api/materials.js
@@ -67,6 +67,12 @@ export const getPurcOrderList = () => {
   return axios.get('/api/materials/purchase-orders/list');
 };
 
+export const getPurcOrderDetailList = () => {
+  return axios.get('/api/materials/purchaseOrders', { 
+    params: { memtype: 'p1' } // 내부직원 권한으로 상세 조회
+  });
+};
+
 export const getPurcOrderWithDetails = (purcCd) => {
   return axios.get(`/api/materials/purchase-orders/${purcCd}`);
 };
@@ -77,6 +83,10 @@ export const savePurchaseOrder = (orderData) => {
 
 export const generatePurchaseCode = () => {
   return axios.post('/api/materials/purchase-orders/generate-code');
+};
+
+export const getPurcOrderDetailListForApproval = () => {
+  return axios.get('/api/materials/purchase-orders/approval-list');
 };
 
 export const getMaterialsWithSuppliers = (searchParams) => {
@@ -134,4 +144,62 @@ export const getMaterialOutboundList = () => {
 
 export const saveMaterialOutbound = (outboundData) => {
   return axios.post('/api/materials/outbound', outboundData);
+};
+
+export const updatePurchaseOrderStatus = (statusData) => {
+  return axios.put('/api/materials/purchase-orders/status', statusData);
+}
+
+export const getPendingApprovalOrders = () => {
+  const params = {
+    purcDStatus: 'c1',
+    ...searchParams
+  };
+
+  Object.keys(params).forEach(key => 
+    (params[key] === null || params[key] === undefined || params[key] === '') && delete params[key]
+  );
+  return axios.get('/api/materials/purchase-orders/pending-approval', { params });
+};
+
+export const getPurchaseOrderStatistics = (dateRange = {}) => {
+  const params = {
+    startDate: dateRange.startDate,
+    endDate: dateRange.endDate
+  };
+  
+  Object.keys(params).forEach(key => 
+    (params[key] === null || params[key] === undefined || params[key] === '') && delete params[key]
+  );
+  
+  return axios.get('/api/materials/purchase-orders/statistics', { params });
+};
+
+export const sendApprovalNotification = (notificationData) => {
+  return axios.post('/api/materials/purchase-orders/notification', notificationData);
+};
+
+export const getPurchaseOrderDetailWithHistory = (purcDCd) => {
+  return axios.get(`/api/materials/purchase-orders/detail/${purcDCd}`);
+};
+
+export const bulkApprovePurchaseOrders = (purcDCdList, approver = 'system') => {
+  const requestData = {
+    purcDCdList: purcDCdList,
+    newStatus: 'c2', // 승인
+    approver: approver
+  };
+  
+  return axios.put('/api/materials/purchase-orders/bulk-status', requestData);
+};
+
+export const bulkRejectPurchaseOrders = (purcDCdList, reason = '', approver = 'system') => {
+  const requestData = {
+    purcDCdList: purcDCdList,
+    newStatus: 'c6', // 거절
+    reason: reason,
+    approver: approver
+  };
+  
+  return axios.put('/api/materials/purchase-orders/bulk-status', requestData);
 };

--- a/kbs/frontend/src/layout/AppMenu.vue
+++ b/kbs/frontend/src/layout/AppMenu.vue
@@ -108,7 +108,7 @@ const model = ref([
             },
             {
                 label: '자재 발주 승인',
-                to: '/material/materialPurchaseConfirm'
+                to: '/material/MaterialPurchaseApproval'
             },
             {
                 label: '자재 출고',

--- a/kbs/frontend/src/router/material.js
+++ b/kbs/frontend/src/router/material.js
@@ -48,9 +48,9 @@ export default [
         component: () => import('@/views/material/MaterialPurchaseView.vue'),
     },
     {
-        path: '/material/MaterialPurchaseConfirm',
-        name: 'materialPurchaseConfirm',
-        component: () => import('@/views/material/MaterialPurchaseConfirm.vue'),
+        path: '/material/MaterialPurchaseApproval',
+        name: 'materialPurchaseApproval',
+        component: () => import('@/views/material/MaterialPurchaseApproval.vue'),
     },
     {
         path: '/material/MaterialOutbound',

--- a/kbs/frontend/src/views/material/MaterialPurchaseApproval.vue
+++ b/kbs/frontend/src/views/material/MaterialPurchaseApproval.vue
@@ -3,16 +3,11 @@ import SearchForm from '@/components/kimbap/searchform/SearchForm.vue';
 import InputTable from '@/components/kimbap/table/InputTable.vue';
 import { useMaterialStore } from '@/stores/materialStore';
 import { storeToRefs } from 'pinia';
+import { useRoute } from 'vue-router';
 import { readonly } from 'vue';
-import { format } from 'date-fns';
-import { useToast } from 'primevue/usetoast';
-import { ref, onMounted } from 'vue';
-import { getPurcOrderList } from '@/api/materials';
 
 const materialStore = useMaterialStore();
 const { searchColumns, purchaseColumns, purchaseData, purchaseFormButtons } = storeToRefs(materialStore);
-const toast = useToast();
-const searchData = ref({});
 
 // 검색 폼 설정
 searchColumns.value = [
@@ -104,21 +99,6 @@ purchaseColumns.value = [
   }
 ];
 
-const getPurc = async () => {
-  try {
-    const response = await getPurcOrderList();
-    if (response && response.data) {
-      purchaseData.value = formatDataDates(response.data);
-    } else {
-      console.warn('발주서 목록이 비어있습니다.');
-      purchaseData.value = [];
-    }
-  } catch (error) {
-    console.error('발주서 목록 불러오기 실패:', error);
-    purchaseData.value = [];
-  }
-};
-
 // 테이블 버튼 설정 - 기존 버튼들 다 숨기기! 🙈
 const materialTableButtons = {
   add: { show: false, label: '추가', severity: 'primary' },
@@ -139,23 +119,6 @@ const handleApprove = () => {
   // 여기에 승인 로직 구현  
   alert('승인 처리되었습니다!');
 };
-
-const formatDataDates = (data) => {
-  return data.map(item => {
-    return {
-      ...item,
-      deliveryDate: format(new Date(item.deliveryDate), 'yyyy-MM-dd'),
-      orderDate: format(new Date(item.orderDate), 'yyyy-MM-dd')
-    };
-  });
-};
-
-
-
-onMounted(() => {
-  console.log('MaterialPurchaseConfirm.vue mounted');
-  getPurc();
-});
 
 </script>
 <template>

--- a/kbs/frontend/src/views/material/MaterialPurchaseView.vue
+++ b/kbs/frontend/src/views/material/MaterialPurchaseView.vue
@@ -10,12 +10,14 @@ import BasicTable from '@/components/kimbap/table/BasicTable.vue';
 import RadioButton from 'primevue/radiobutton';
 import { format, isValid } from 'date-fns';
 import { useCommonStore } from '@/stores/commonStore';
+import InputTable from '@/components/kimbap/table/InputTable.vue';
 
 // Store 및 Toast
 const materialStore = useMaterialStore();
 const memberStore = useMemberStore();
 const common = useCommonStore();
 const toast = useToast();
+
 const formatDate = (date) => {
   if (!date) return '';
   
@@ -76,6 +78,14 @@ const formatDataDates = (dataList) => {
 const userType = ref('internal');
 const isLoading = ref(false);
 const showTestControls = ref(true);
+
+// 🔥 여기가 중요! materialTableButtons를 밖으로 빼냈어!
+const materialTableButtons = ref({
+  add: { show: false, label: '추가', severity: 'primary' },
+  edit: { show: false, label: '수정', severity: 'secondary' },
+  delete: { show: false, label: '삭제', severity: 'danger' },
+  save: { show: false, label: '저장', severity: 'success' }
+});
 
 // 실제 사용자 권한 기반 타입 설정
 const actualUserType = computed(() => {
@@ -179,6 +189,24 @@ const convertedTableData = computed(() => {
   return convertUnitCodes(rawData);
 });
 
+// 강제 재렌더링용
+const forceRenderKey = ref(0);
+const forceRender = () => {
+  forceRenderKey.value++;
+  console.log('🔄 강제 재렌더링 실행:', forceRenderKey.value);
+};
+
+// convertedTableData 변화 감지
+watch(convertedTableData, (newData) => {
+  console.log('🔥 convertedTableData 변경됨:', newData?.length || 0, '건');
+  console.log('첫 번째 데이터:', newData?.[0]);
+}, { immediate: true, deep: true });
+
+// materialStore 데이터 직접 감지
+watch(() => materialStore.purchaseOrderDetailData, (newData) => {
+  console.log('🏪 Store 데이터 변경됨:', newData?.length || 0, '건');
+}, { immediate: true, deep: true });
+
 // 생명주기
 onMounted(async () => {
   // 공통코드 로드 추가
@@ -193,7 +221,7 @@ onMounted(async () => {
   loadPurchaseData();
 });
 
-// 샘플 데이터 로드 (백업용)
+// 샘플 데이터 로드 (백업용) - 🔥 materialTableButtons 제거!
 const loadSampleData = () => {
   console.log('샘플 데이터 로드');
   const sampleData = [
@@ -239,6 +267,15 @@ const loadSampleData = () => {
       <div class="card">
         <h5>자재 구매/발주 관리</h5>
 
+        <!-- 🔥 디버깅 정보 추가! -->
+        <div class="mb-4 p-3 bg-yellow-100 border border-yellow-400 rounded">
+          <h6 class="text-yellow-800">🐛 디버깅 정보</h6>
+          <p><strong>convertedTableData 길이:</strong> {{ convertedTableData?.length || 0 }}</p>
+          <p><strong>store 데이터 길이:</strong> {{ materialStore.purchaseOrderDetailData?.length || 0 }}</p>
+          <p><strong>첫 번째 데이터:</strong></p>
+          <pre class="text-xs">{{ JSON.stringify(convertedTableData?.[0], null, 2) }}</pre>
+        </div>
+
         <!-- 현재 사용자 정보 표시 -->
         <div class="mb-4 p-3 border-round surface-100">
           <div class="flex align-items-center gap-3">
@@ -246,7 +283,7 @@ const loadSampleData = () => {
             <div>
               <strong>{{ memberStore.user?.empName || '테스트 사용자' }}</strong>
               <span class="ml-2 text-500">
-                ({{ actualUserType === 'internal' ? '내부직원' : '공급업체직원' }})
+                ({{ actualUserType === 'internal' ? '내부직원' : '공급업체용' }})
               </span>
             </div>
           </div>
@@ -277,19 +314,62 @@ const loadSampleData = () => {
           @reset="onReset"
         />
 
-        <!-- 데이터 테이블 -->
+        <!-- 기본 데이터 테이블 -->
         <BasicTable 
           :data="convertedTableData"
           :columns="currentTableColumns"
-          :title="`발주 목록 (${actualUserType === 'internal' ? '내부직원용' : '공급업체용'})`"
+          :title="`BasicTable 발주 목록 (${actualUserType === 'internal' ? '내부직원용' : '공급업체용'})`"
           :loading="isLoading"
           selectionMode="single"
         />
 
+        <!-- 🎯 InputTable - 강제로 key 추가해서 재렌더링 유도 -->
+        <InputTable
+          :key="`input-table-${convertedTableData?.length || 0}`"
+          :columns="currentTableColumns"
+          :data="convertedTableData"
+          :scroll-height="'50vh'" 
+          :height="'60vh'"
+          :title="`InputTable 발주 목록 (${actualUserType === 'internal' ? '내부직원용' : '공급업체용'})`"
+          dataKey="purcDCd"
+          :buttons="materialTableButtons"
+          :enableRowActions="false"
+          :enableSelection="false"
+          @dataChange="(newData) => console.log('InputTable 데이터 변경:', newData)"
+        />
+
+        <!-- 🔥 원본 데이터 직접 테스트 -->
+        <div class="mt-4 p-4 bg-blue-50 border border-blue-200 rounded">
+          <h6 class="text-blue-800">🧪 원본 데이터 직접 테스트</h6>
+          <InputTable
+            :key="`raw-test-${Date.now()}`"
+            :columns="[
+              { field: 'purcDCd', header: '발주상세코드', type: 'readonly' },
+              { field: 'mateName', header: '자재명', type: 'readonly' },
+              { field: 'purcQty', header: '수량', type: 'readonly' },
+              { field: 'unit', header: '단위', type: 'readonly' }
+            ]"
+            :data="[
+              { purcDCd: 'TEST-001', mateName: '테스트자재1', purcQty: 100, unit: 'kg' },
+              { purcDCd: 'TEST-002', mateName: '테스트자재2', purcQty: 200, unit: 'ea' }
+            ]"
+            :scroll-height="'30vh'" 
+            :height="'40vh'"
+            title="🧪 하드코딩 테스트 데이터"
+            dataKey="purcDCd"
+            :buttons="{ save: { show: false }, reset: { show: false } }"
+            :enableRowActions="false"
+            :enableSelection="false"
+          />
+        </div>
+
         <!-- 강제 새로고침 버튼 (테스트용) -->
         <div class="mt-4" v-if="showTestControls">
-          <button @click="loadPurchaseData" class="p-button p-button-secondary">
+          <button @click="loadPurchaseData" class="p-button p-button-secondary mr-2">
             데이터 강제 새로고침
+          </button>
+          <button @click="forceRender" class="p-button p-button-info">
+            강제 재렌더링
           </button>
         </div>
       </div>


### PR DESCRIPTION
feat: 승인 기능을 통한 구매 주문 관리 강화

- 직원명과 구매 상태를 위한 새로운 필드를 MaterialsVO에 추가함.
- 승인용 구매 주문 세부사항 조회 및 구매 주문 상태 업데이트를 위한 메소드를 MateServiceImpl에 구현함.
- 승인 대기 주문 조회 및 구매 주문 상태 업데이트를 위한 새로운 엔드포인트를 MateController에 생성함.
- 구매 주문 세부사항 조회 및 상태 업데이트를 위한 SQL 쿼리를 포함하도록 MateMapper.xml을 업데이트함.
- 새로운 승인 기능을 위한 프론트엔드 API 호출을 materials.js에서 강화함.
- 새로운 자재 구매 승인 뷰를 포함하도록 AppMenu와 라우팅을 업데이트함.
- 구매 주문 승인 표시 및 관리를 위한 MaterialPurchaseApproval.vue를 개발함.
- 새로운 입력 테이블과 디버깅 기능을 통합하도록 MaterialPurchaseView.vue를 리팩토링함.